### PR TITLE
test: improve test coverage and add CI/CD pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,74 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  check:
+    name: Check & Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: cargo fmt --check
+        run: cargo fmt --all -- --check
+
+      - name: cargo clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: cargo check
+        run: cargo check --workspace
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: cargo test
+        run: cargo test --workspace
+
+  build-cli:
+    name: Build CLI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build CLI (release)
+        run: cargo build --release -p toolbox-cli
+
+  build-wasm:
+    name: Build WASM Plugin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasip1
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build Zellij plugin (WASM)
+        run: cargo build --release -p toolbox-zellij --target wasm32-wasip1

--- a/toolbox-cli/Cargo.toml
+++ b/toolbox-cli/Cargo.toml
@@ -16,3 +16,8 @@ clap = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 toml = { workspace = true }
+
+[dev-dependencies]
+assert_cmd = "2.0"
+predicates = "3.0"
+tempfile = "3"

--- a/toolbox-cli/src/main.rs
+++ b/toolbox-cli/src/main.rs
@@ -160,7 +160,7 @@ fn handle_command(command: &Commands, cli: &Cli) -> Result<()> {
         Commands::ListTools => {
             let config = Config::default();
             println!("Available tools:\n");
-            for tool in &config.tools {
+            for tool in &config.effective_tools() {
                 let status = if tool.enabled { "enabled" } else { "disabled" };
                 let icon = tool.icon.as_deref().unwrap_or(" ");
                 println!("  {} {} ({}) - {}", icon, tool.name, status, tool.command);

--- a/toolbox-cli/tests/cli_integration.rs
+++ b/toolbox-cli/tests/cli_integration.rs
@@ -1,0 +1,288 @@
+use predicates::prelude::*;
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+fn toolbox_cmd() -> assert_cmd::Command {
+    assert_cmd::cargo::cargo_bin_cmd!("toolbox")
+}
+
+// --- Default execution (tool version display) ---
+
+#[test]
+fn test_default_output_succeeds() {
+    toolbox_cmd().assert().success();
+}
+
+#[test]
+fn test_default_output_with_no_icons() {
+    toolbox_cmd().arg("--no-icons").assert().success();
+}
+
+#[test]
+fn test_default_output_compact() {
+    toolbox_cmd().arg("--compact").assert().success();
+}
+
+// --- JSON output ---
+
+#[test]
+fn test_json_output_is_valid_json() {
+    let output = toolbox_cmd()
+        .args(["--format", "json"])
+        .output()
+        .expect("failed to execute");
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: Result<serde_json::Value, _> = serde_json::from_str(stdout.trim());
+    assert!(parsed.is_ok(), "Output is not valid JSON: {}", stdout);
+}
+
+#[test]
+fn test_json_output_has_tools_field() {
+    let output = toolbox_cmd()
+        .args(["--format", "json"])
+        .output()
+        .expect("failed to execute");
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert!(
+        parsed.get("tools").is_some(),
+        "JSON should have 'tools' field"
+    );
+}
+
+#[test]
+fn test_json_pretty_output_is_valid() {
+    let output = toolbox_cmd()
+        .args(["--format", "json-pretty"])
+        .output()
+        .expect("failed to execute");
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: Result<serde_json::Value, _> = serde_json::from_str(stdout.trim());
+    assert!(parsed.is_ok(), "Output is not valid JSON: {}", stdout);
+}
+
+// --- Powerline output ---
+
+#[test]
+fn test_powerline_output_succeeds() {
+    toolbox_cmd().arg("--powerline").assert().success();
+}
+
+#[test]
+fn test_powerline_single_line_succeeds() {
+    toolbox_cmd()
+        .args(["--powerline", "--single-line"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_powerline_with_color_always() {
+    toolbox_cmd()
+        .args(["--powerline", "--color", "always"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_powerline_with_color_never() {
+    toolbox_cmd()
+        .args(["--powerline", "--color", "never"])
+        .assert()
+        .success();
+}
+
+// --- Subcommands ---
+
+#[test]
+fn test_list_tools_subcommand() {
+    toolbox_cmd()
+        .arg("list-tools")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Available tools"))
+        .stdout(predicate::str::contains("Python"));
+}
+
+#[test]
+fn test_list_tools_shows_enabled_status() {
+    let output = toolbox_cmd()
+        .arg("list-tools")
+        .output()
+        .expect("failed to execute");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("enabled") || stdout.contains("disabled"),
+        "list-tools should show enabled/disabled status"
+    );
+}
+
+#[test]
+fn test_show_config_subcommand() {
+    // show-config will use default config if no config file exists
+    toolbox_cmd().arg("show-config").assert().success();
+}
+
+#[test]
+fn test_init_subcommand_creates_config() {
+    let temp_file = NamedTempFile::new().unwrap();
+    let path = temp_file.path().to_path_buf();
+    // Remove the file so init can create it
+    std::fs::remove_file(&path).unwrap();
+
+    toolbox_cmd()
+        .args(["--config", path.to_str().unwrap(), "init"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Created config file"));
+
+    // Verify file was created
+    assert!(path.exists(), "Config file should be created");
+
+    // Verify it's valid TOML
+    let content = std::fs::read_to_string(&path).unwrap();
+    let parsed: Result<toml::Value, _> = toml::from_str(&content);
+    assert!(parsed.is_ok(), "Created config should be valid TOML");
+}
+
+#[test]
+fn test_init_subcommand_refuses_overwrite_without_force() {
+    let mut temp_file = NamedTempFile::new().unwrap();
+    writeln!(temp_file, "existing content").unwrap();
+    let path = temp_file.path().to_path_buf();
+
+    toolbox_cmd()
+        .args(["--config", path.to_str().unwrap(), "init"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("already exists"));
+}
+
+#[test]
+fn test_init_subcommand_force_overwrite() {
+    let mut temp_file = NamedTempFile::new().unwrap();
+    writeln!(temp_file, "old content").unwrap();
+    let path = temp_file.path().to_path_buf();
+
+    toolbox_cmd()
+        .args(["--config", path.to_str().unwrap(), "init", "--force"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Created config file"));
+}
+
+// --- Custom config file ---
+
+#[test]
+fn test_custom_config_file() {
+    let mut temp_file = NamedTempFile::new().unwrap();
+    writeln!(
+        temp_file,
+        r#"
+use_default_tools = false
+
+[display]
+show_icons = false
+compact = true
+
+[[custom_tools]]
+name = "Echo"
+command = "echo v1.0.0"
+parse_regex = 'v?(\d+\.\d+\.\d+)'
+enabled = true
+
+[extras]
+git_branch = false
+git_status = false
+current_directory = false
+virtual_env = false
+system_memory = false
+system_cpu = false
+"#
+    )
+    .unwrap();
+
+    let path = temp_file.path().to_path_buf();
+
+    let output = toolbox_cmd()
+        .args(["--config", path.to_str().unwrap(), "--format", "json"])
+        .output()
+        .expect("failed to execute");
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    let tools = parsed["tools"].as_array().unwrap();
+
+    assert_eq!(tools.len(), 1, "Should have exactly one tool");
+    assert_eq!(tools[0]["name"], "Echo");
+    assert_eq!(tools[0]["version"], "1.0.0");
+    assert!(tools[0]["available"].as_bool().unwrap());
+}
+
+#[test]
+fn test_invalid_config_file_errors() {
+    let mut temp_file = NamedTempFile::new().unwrap();
+    writeln!(temp_file, "invalid toml {{{{").unwrap();
+    let path = temp_file.path().to_path_buf();
+
+    toolbox_cmd()
+        .args(["--config", path.to_str().unwrap()])
+        .assert()
+        .failure();
+}
+
+// --- --help and --version ---
+
+#[test]
+fn test_help_flag() {
+    toolbox_cmd()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Display development tool versions",
+        ));
+}
+
+#[test]
+fn test_version_flag() {
+    toolbox_cmd()
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("toolbox"));
+}
+
+// --- Working directory ---
+
+#[test]
+fn test_working_dir_option() {
+    toolbox_cmd()
+        .args(["--dir", "/tmp", "--format", "json"])
+        .assert()
+        .success();
+}
+
+// --- Color modes ---
+
+#[test]
+fn test_color_auto() {
+    toolbox_cmd().args(["--color", "auto"]).assert().success();
+}
+
+#[test]
+fn test_color_always() {
+    toolbox_cmd().args(["--color", "always"]).assert().success();
+}
+
+#[test]
+fn test_color_never() {
+    toolbox_cmd().args(["--color", "never"]).assert().success();
+}

--- a/toolbox-core/src/config.rs
+++ b/toolbox-core/src/config.rs
@@ -585,8 +585,10 @@ mod tests {
 
     #[test]
     fn test_use_default_tools_false() {
-        let mut config = Config::default();
-        config.use_default_tools = false;
+        let mut config = Config {
+            use_default_tools: false,
+            ..Config::default()
+        };
         config.custom_tools.push(ToolConfig {
             name: "OnlyThis".to_string(),
             command: "only-this --version".to_string(),

--- a/toolbox-core/src/detector.rs
+++ b/toolbox-core/src/detector.rs
@@ -586,12 +586,17 @@ mod tests {
     #[test]
     fn test_detect_all_returns_toolbox_info() {
         // Create a minimal config to speed up the test
-        let mut config = Config::default();
-        config.use_default_tools = false; // Disable default tools
-        config.extras.git_branch = false;
-        config.extras.git_status = false;
-        config.extras.system_memory = false;
-        config.extras.system_cpu = false;
+        let config = Config {
+            use_default_tools: false,
+            extras: crate::config::ExtrasConfig {
+                git_branch: false,
+                git_status: false,
+                system_memory: false,
+                system_cpu: false,
+                ..Default::default()
+            },
+            ..Config::default()
+        };
 
         let detector = ToolDetector::new(config);
         let info = detector.detect_all();

--- a/toolbox-core/src/error.rs
+++ b/toolbox-core/src/error.rs
@@ -28,3 +28,68 @@ pub enum ToolboxError {
 }
 
 pub type Result<T> = std::result::Result<T, ToolboxError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_display_config() {
+        let err = ToolboxError::Config("bad config".to_string());
+        assert_eq!(err.to_string(), "Configuration error: bad config");
+    }
+
+    #[test]
+    fn test_error_display_command_failed() {
+        let err = ToolboxError::CommandFailed("python: not found".to_string());
+        assert_eq!(
+            err.to_string(),
+            "Command execution failed: python: not found"
+        );
+    }
+
+    #[test]
+    fn test_error_display_version_parse() {
+        let err = ToolboxError::VersionParse("no match".to_string());
+        assert_eq!(err.to_string(), "Version parse error: no match");
+    }
+
+    #[test]
+    fn test_error_from_io() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file missing");
+        let err = ToolboxError::from(io_err);
+        assert!(err.to_string().contains("file missing"));
+    }
+
+    #[test]
+    fn test_error_from_toml() {
+        let toml_result: std::result::Result<toml::Value, _> = toml::from_str("invalid {{");
+        let toml_err = toml_result.unwrap_err();
+        let err = ToolboxError::from(toml_err);
+        assert!(err.to_string().contains("TOML parse error"));
+    }
+
+    #[test]
+    fn test_error_from_regex() {
+        let bad_regex = "[invalid(";
+        let regex_err = regex::Regex::new(bad_regex).unwrap_err();
+        let err = ToolboxError::from(regex_err);
+        assert!(err.to_string().contains("Regex error"));
+    }
+
+    #[test]
+    fn test_result_type_ok() {
+        let result: Result<i32> = Ok(42);
+        assert!(result.is_ok());
+        match result {
+            Ok(v) => assert_eq!(v, 42),
+            Err(_) => panic!("expected Ok"),
+        }
+    }
+
+    #[test]
+    fn test_result_type_err() {
+        let result: Result<i32> = Err(ToolboxError::Config("test".to_string()));
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
- Add GitHub Actions CI workflow (fmt, clippy, test, build CLI/WASM)
- Add CLI integration tests with assert_cmd + predicates (24 tests)
- Expand color.rs unit tests: all segment types, multiline, edge cases (4 -> 30 tests)
- Add error.rs unit tests: Display impl, From conversions (8 tests)
- Expand info.rs unit tests: powerline, system info, virtual env, JSON roundtrip (24 -> 45 tests)
- Fix list-tools to use effective_tools() instead of empty tools vec
- Fix clippy warnings in existing test code
- Add mandatory testing rules to CLAUDE.md

Test count: 69 -> 147 (24 CLI integration + 123 unit tests)

https://claude.ai/code/session_01SJLYfT1a3DFBKvhncyqvK7