### PR TITLE
feat: add `toolbox doctor` diagnostic subcommand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,12 @@ toolbox show-config
 
 # 利用可能なツール一覧
 toolbox list-tools
+
+# ツール検出環境の診断
+toolbox doctor
+
+# 診断結果をJSON出力
+toolbox doctor --json
 ```
 
 ## アーキテクチャ
@@ -91,8 +97,9 @@ toolbox list-tools
 ### toolbox-core
 
 - `Config`: TOML設定ファイルの読み書き（24ツールのデフォルト定義、カスタムツール追加、オーバーライド対応）
-- `ToolDetector`: ツールバージョン検出のメインロジック（asdf/mise対応、Git ahead/behind追跡）
+- `ToolDetector`: ツールバージョン検出のメインロジック（asdf/mise対応、Git ahead/behind追跡、診断機能）
 - `ToolInfo`, `GitInfo`, `SystemInfo`: 情報を格納する構造体
+- `ToolDiagnostic`, `DiagnosticSummary`: ツール診断結果を格納する構造体
 - Powerlineスタイルの表示フォーマット（シングルライン・マルチライン）
 - ANSIカラー出力（auto/always/never切替）
 
@@ -110,6 +117,7 @@ CLIインターフェース。clap使用。
 - `init`: 設定ファイル生成
 - `show-config`: 現在の設定を表示
 - `list-tools`: 利用可能なツール一覧
+- `doctor`: ツール検出環境の診断（`--json` でJSON出力対応）
 
 オプション:
 - `-c, --config`: 設定ファイルパス
@@ -143,6 +151,7 @@ ZellijのWASMプラグイン。CLIを呼び出して結果を表示する。
 - [x] 24ツールのデフォルト定義
 - [x] 仮想環境検出（Python venv, Conda）
 - [x] DevContainer設定
+- [x] `toolbox doctor` 診断サブコマンド（ツール検出環境の診断、JSON出力対応）
 
 ## テストルール（必須）
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A Zellij plugin for displaying development tool versions at a glance.
 - Powerline-style colored output (single-line and multiline)
 - Virtual environment detection (Python venv, Conda)
 - CLI tool for standalone usage
+- `toolbox doctor` diagnostic command for troubleshooting tool detection
 - Zellij WASM plugin with auto-refresh
 
 ## Installation
@@ -82,6 +83,12 @@ toolbox show-config
 
 # List available tools
 toolbox list-tools
+
+# Diagnose tool detection (check what's found, what's missing)
+toolbox doctor
+
+# Diagnose with JSON output
+toolbox doctor --json
 ```
 
 ### Zellij Plugin
@@ -195,7 +202,7 @@ cargo build -p toolbox-zellij --target wasm32-wasip1 --release
 ### Test
 
 ```bash
-# Run all tests (69 unit tests)
+# Run all tests
 cargo test
 
 # Run specific crate tests

--- a/toolbox-core/src/lib.rs
+++ b/toolbox-core/src/lib.rs
@@ -16,4 +16,6 @@ pub mod info;
 pub use config::Config;
 pub use detector::ToolDetector;
 pub use error::ToolboxError;
-pub use info::{GitInfo, SystemInfo, ToolInfo, ToolboxInfo};
+pub use info::{
+    DiagnosticStatus, DiagnosticSummary, GitInfo, SystemInfo, ToolDiagnostic, ToolInfo, ToolboxInfo,
+};


### PR DESCRIPTION
Add a `doctor` subcommand that diagnoses tool detection environment,
reporting OK/Warning/Error status for each configured tool with
resolved command paths, version info, and actionable suggestions.
Supports `--json` output for programmatic use.

- Add DiagnosticStatus, ToolDiagnostic, DiagnosticSummary types
- Add diagnose_tool/diagnose_all methods to ToolDetector
- Add Doctor variant to CLI Commands enum
- Add unit tests (detector + info) and CLI integration tests
- Update CLAUDE.md and README.md documentation

https://claude.ai/code/session_01Lu6eqB1ytL1xMiRTQvCjUV